### PR TITLE
Fix two hot

### DIFF
--- a/ppo_v3/ppo_envpool_tricks.py
+++ b/ppo_v3/ppo_envpool_tricks.py
@@ -215,7 +215,7 @@ class Agent(nn.Module):
         )
         self.actor = layer_init(nn.Linear(512, envs.single_action_space.n), std=0.01)
 
-        self.B = torch.nn.Parameter(torch.linspace(-20, 20, 128)) # (256, )
+        self.B = torch.nn.Parameter(torch.linspace(-20, 20, 256)) # (256, )
         self.B.requires_grad = False
 
         critic_std = 0.01 if args.critic_zero_init else 1.
@@ -409,7 +409,8 @@ if __name__ == "__main__":
 
                 # Value loss
                 if args.two_hot:
-                    twohot_target = calc_twohot(symlog(b_returns[mb_inds]), agent.B)
+                    with torch.no_grad(): # does this matter? Nothing in `calc_twohot` seems to require grad
+                        twohot_target = calc_twohot(symlog(b_returns[mb_inds]), agent.B)
                     v_loss = nn.functional.cross_entropy(newlogitscritic, twohot_target, reduction='mean')
                 else:
                     newvalue = newvalue.view(-1)


### PR DESCRIPTION
The target is calculated as twohot_target = calc_twohot(b_returns[mb_inds], agent.B),  but the paper says

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/5555347/222836577-e3ab1f8a-9505-41df-b7a3-eb934501d446.png">

This PR submits a potential fix. Experiments are running in https://wandb.ai/dream-team-v3/PPO-v3/reports/Symlog-and-Two-Hot-Debug--VmlldzozNjk2NjQy