### PR TITLE
Remove symlog for image observations

### DIFF
--- a/ppo_v3/ppo_envpool_tricks.py
+++ b/ppo_v3/ppo_envpool_tricks.py
@@ -236,12 +236,12 @@ class Agent(nn.Module):
         return val, logits_critic
 
     def get_value(self, x):
-        x = symlog(x) if self.args.symlog else x / 255.0
+        x = x / 255.0
         val, _ = self.critic_val(self.network(x))
         return val
 
     def get_action_and_value(self, x, action=None):
-        x = symlog(x) if self.args.symlog else x / 255.0
+        x = x / 255.0
         hidden = self.network(x)
         logits = self.actor(hidden)
         dist = Categorical(logits=logits)


### PR DESCRIPTION
We should not be applying symlog to image observations because their values are already bounded. It only makes sense for continuous observations. symlog(x) is likely a much worse scaling scheme than x / 255.0 for images.

This is briefly mentioned in the NoSymObs ablation description:
> This ablation removes the symlog encoding of inputs to the world model and also changes the symlog MSE loss in the decoder to a simple MSE loss. Because symlog encoding is only used for vector observations, this ablation is equivalent to DreamerV3 on purely image-based environments.